### PR TITLE
feat: add region support

### DIFF
--- a/components/crowdstrike-falcon-install-linux.yml
+++ b/components/crowdstrike-falcon-install-linux.yml
@@ -15,6 +15,13 @@ parameters:
       allowedValues:
         - "SecretsManager"
         - "ParamaterStore"
+  - AWSRegion:
+      type: string
+      default: "us-east-1"
+      description:
+        The AWS Region (e.g. us-east-1, eu-west-1) where either the Secrets Manager
+        secret or SSM Parameter Store parameter containing the Falcon API credentials are
+        stored.
   - SecretsManagerSecretName:
       type: string
       default: "/CrowdStrike/Falcon/Image-Builder"
@@ -93,7 +100,7 @@ phases:
         inputs:
           commands:
             - >
-              # aws secretsmanager get-secret-value --secret-id "{{ SecretsManagerSecretName }}" --query 'SecretString' --output text
+              # aws secretsmanager get-secret-value --secret-id "{{ SecretsManagerSecretName }}" --query 'SecretString' --output text --region "{{ AWSRegion }}"
 
       - name: FalconPrep
         action: ExecuteBash
@@ -113,6 +120,7 @@ phases:
               "{{ ProxyHost }}"
               "{{ ProxyPort }}"
               "{{ Billing }}"
+              "{{ AWSRegion }}"
 
   - name: validate
     steps:

--- a/scripts/deploy-falcon-linux.sh
+++ b/scripts/deploy-falcon-linux.sh
@@ -44,11 +44,11 @@ AWS_CLI_REGION="${13:-}"
 
 log() {
     local log_level=${2:-INFO}
-    echo "[$(date +'%Y-%m-%dT%H:%M:%S')] $log_level: $1" >&2
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S')] $log_level: $1"
 }
 
 die() {
-    log "$1" "ERROR"
+    log "$1" "ERROR" >&2
     exit 1
 }
 

--- a/scripts/deploy-falcon-linux.sh
+++ b/scripts/deploy-falcon-linux.sh
@@ -17,6 +17,7 @@ TAGS="${9:-}"
 PROXY_HOST="${10:-}"
 PROXY_PORT="${11:-}"
 BILLING="${12:-}"
+AWS_CLI_REGION="${13:-}"
 # INSTALLED_AWS_CLI=false
 
 ## DEBUG INPUTS ##
@@ -111,6 +112,16 @@ validate_auth_input() {
             [[ "$invalid" == true ]] && exit 1
             ;;
     esac
+}
+
+set_cli_region() {
+    # Validate AWS_CLI_REGION then set
+    if [[ -z "$AWS_CLI_REGION" ]]; then
+        die "AWSRegion parameter was not provided."
+    else
+        log "Setting AWS CLI region to: $AWS_CLI_REGION"
+        export AWS_DEFAULT_REGION="$AWS_CLI_REGION"
+    fi
 }
 
 ### Validate AWS CLI
@@ -228,6 +239,7 @@ install_falcon_sensor() {
 main() {
     sanitize_input_params
     validate_auth_input
+    set_cli_region
 
     case $SECRET_STORAGE_METHOD in
         "SecretsManager")


### PR DESCRIPTION
Adds the ability to set your AWS Region in which your credentials are stored. This allows more flexibility when running the pipeline from a region that might not contain your creds.

Also fixed an issue where the log() was redirecting all output to STDERR. 